### PR TITLE
fix error by CORS

### DIFF
--- a/pwacompat.js
+++ b/pwacompat.js
@@ -207,6 +207,7 @@
     }
     const icon = appleTouchIcons[0];
     const img = new Image();
+    img.crossOrigin = "anonymous";
     img.onload = () => {
       updateSplash(img);
 
@@ -223,6 +224,7 @@
       // fetch and fix all remaining icons
       appleTouchIcons.slice(1).forEach((icon) => {
         const img = new Image();
+        img.crossOrigin = "anonymous";
         img.onload = () => {
           const redrawn = updateTransparent(img, manifest['background_color'], true);
           icon.href = redrawn;


### PR DESCRIPTION
When the image URL of the icon is different, error occurs.

```
SecurityError (DOM Exception 18): The operation is insecure.
```

Please confirm as we want to resolve this error.
