### PR TITLE
Check if nodes were present before appending them

### DIFF
--- a/src/pwacompat.js
+++ b/src/pwacompat.js
@@ -151,6 +151,7 @@ function unused() {
 
   /**
    * Adds an element in the <head> if it's not present already
+   * nb: we check, but this won't override any _earlier_ (in DOM order)
    * @param {string} localName tag name
    * @param {*} attr key-value collection of attributes
    */
@@ -243,10 +244,7 @@ function unused() {
       meta('msapplication-TileColor', manifest['background_color']);
     }
 
-    // nb: we check, but this won't override any _earlier_ (in DOM order) theme-color
-    if (!isMetaPresent('theme-color')) {
-      meta('theme-color', manifest['theme_color']);
-    }
+    meta('theme-color', manifest['theme_color']);
 
     if (!isSafariMobile) {
       // TODO(samthor): We don't detect QQ or UC, we just set the vars anyway.

--- a/src/pwacompat.js
+++ b/src/pwacompat.js
@@ -154,7 +154,7 @@ function unused() {
    * Adds an element in the <head> if it's not present already
    * nb: we check, but this won't override any _earlier_ (in DOM order)
    * @param {string} localName tag name
-   * @param {*} attr key-value collection of attributes
+   * @param {!Object<string>} attr key-value collection of attributes
    */
   function push(localName, attr) {
     if (localName === 'meta' && isMetaPresent(attr.name)) {

--- a/src/pwacompat.js
+++ b/src/pwacompat.js
@@ -77,10 +77,11 @@ function unused() {
 
   /**
    * Checks if link is present
-   * @param {string} href link's href
+   * @param {string} attr link's attribute, `href by default`
+   * @param {string} href link's attr value
    */
-  function isLinkPresent(href) {
-    return !!getElementInHead('link[href="' + href + '"]');
+  function isLinkPresent(attr = 'href', value) {
+    return !!getElementInHead('link[' + attr + '="' + value + '"]');
   }
 
   /**
@@ -159,7 +160,13 @@ function unused() {
     if (localName === 'meta' && isMetaPresent(attr.name)) {
       return;
     }
-    if (localName === 'link' && isLinkPresent(attr.href)) {
+    // in case of links, comparing either href or sizes (because it's used for icons too)
+    if (
+      localName === 'link' &&
+      (isLinkPresent('href', attr.href) ||
+        (attr.sizes && isLinkPresent('sizes', attr.sizes))
+      )
+    ) {
       return
     }
     const node = document.createElement(localName);

--- a/src/pwacompat.js
+++ b/src/pwacompat.js
@@ -167,7 +167,7 @@ function unused() {
         (attr.sizes && isLinkPresent('sizes', attr.sizes))
       )
     ) {
-      return
+      return;
     }
     const node = document.createElement(localName);
     for (const k in attr) {

--- a/src/pwacompat.js
+++ b/src/pwacompat.js
@@ -59,6 +59,31 @@ function unused() {
   internalStorage = internalStorage || {};
 
   /**
+   * Retrieves element in head if available, otherwise null
+   * @param {string} selector CSS selector
+   * @returns {Element|null}
+   */
+  function getElementInHead(selector) {
+    return document.head.querySelector(selector);
+  }
+
+  /**
+   * Checks if meta tag is present
+   * @param {string} name meta's name
+   */
+  function isMetaPresent(name) {
+    return !!getElementInHead('meta[name="' + name + '"]');
+  }
+
+  /**
+   * Checks if link is present
+   * @param {string} href link's href
+   */
+  function isLinkPresent(href) {
+    return !!getElementInHead('link[href="' + href + '"]');
+  }
+
+  /**
    * @param {string} k
    * @param {string=} v
    * @return {string|undefined}
@@ -72,7 +97,7 @@ function unused() {
   }
 
   function setup() {
-    manifestEl = document.head.querySelector('link[rel="manifest"]');
+    manifestEl = getElementInHead('link[rel="manifest"]');
     const manifestHref = manifestEl ? manifestEl.href : '';
     if (!manifestHref) {
       throw `can't find <link rel="manifest" href=".." />'`;
@@ -124,7 +149,18 @@ function unused() {
     return (part) => part || '';
   }
 
+  /**
+   * Adds an element in the <head> if it's not present already
+   * @param {string} localName tag name
+   * @param {*} attr key-value collection of attributes
+   */
   function push(localName, attr) {
+    if (localName === 'meta' && isMetaPresent(attr.name)) {
+      return;
+    }
+    if (localName === 'link' && isLinkPresent(attr.link)) {
+      return
+    }
     const node = document.createElement(localName);
     for (const k in attr) {
       node.setAttribute(k, attr[k]);
@@ -184,7 +220,7 @@ function unused() {
     }).filter(Boolean);
 
     // nb. only for iOS, but watch for future CSS rule `@viewport { viewport-fit: cover; }`
-    const metaViewport = document.head.querySelector('meta[name="viewport"]');
+    const metaViewport = getElementInHead('meta[name="viewport"]');
     const viewport = metaViewport && metaViewport.content || '';
     const viewportFitCover = Boolean(viewport.match(/\bviewport-fit\s*=\s*cover\b/));
 
@@ -208,7 +244,7 @@ function unused() {
     }
 
     // nb: we check, but this won't override any _earlier_ (in DOM order) theme-color
-    if (!document.head.querySelector('[name="theme-color"]')) {
+    if (!isMetaPresent('theme-color')) {
       meta('theme-color', manifest['theme_color']);
     }
 

--- a/src/pwacompat.js
+++ b/src/pwacompat.js
@@ -159,7 +159,7 @@ function unused() {
     if (localName === 'meta' && isMetaPresent(attr.name)) {
       return;
     }
-    if (localName === 'link' && isLinkPresent(attr.link)) {
+    if (localName === 'link' && isLinkPresent(attr.href)) {
       return
     }
     const node = document.createElement(localName);

--- a/src/suite.js
+++ b/src/suite.js
@@ -109,5 +109,21 @@ suite('pwacompat', () => {
     assert.isNotNull(r.querySelector('link[rel="icon"][href="logo-128.png"][sizes="128x128"]'));
   });
 
+  suite('prevent creating existing nodes, example: mobile-web-app-capable', () => {
+    const manifest = {
+      display: 'standalone' // pwacompat should add 'meta[name="mobile-web-app-capable"][content="yes"]'
+    };
+    test('should add `mobile-web-app-capable`', async () => {
+      const r = await testManifest(manifest);
+      assert.isNotNull(r.querySelector('meta[name="mobile-web-app-capable"][content="yes"]'));
+    });
+    test('should not add `mobile-web-app-capable` if it was present beforehand', async () => {
+      const r = await testManifest(manifest, '<meta name="mobile-web-app-capable" content="existing">');
+      assert.isNotNull(r.querySelector('meta[name="mobile-web-app-capable"][content="existing"]'));
+      assert.isNull(r.querySelector('meta[name="mobile-web-app-capable"][content="yes"]'));
+      assert.lengthOf(r.querySelectorAll('meta[name="mobile-web-app-capable"]'), 1, 'found only one node')
+    });
+  })
+
   // TODO(samthor): Emulate/force userAgent and other environments to test Edge/iOS.
 });

--- a/src/suite.js
+++ b/src/suite.js
@@ -109,21 +109,36 @@ suite('pwacompat', () => {
     assert.isNotNull(r.querySelector('link[rel="icon"][href="logo-128.png"][sizes="128x128"]'));
   });
 
-  suite('prevent creating existing nodes, example: mobile-web-app-capable', () => {
+  test('should add meta `mobile-web-app-capable`', async () => {
+    const manifest = {
+      display: 'standalone'
+    };
+    const r = await testManifest(manifest);
+    assert.isNotNull(r.querySelector('meta[name="mobile-web-app-capable"][content="yes"]'));
+  });
+
+  test('should not add meta `mobile-web-app-capable` if it was present beforehand', async () => {
     const manifest = {
       display: 'standalone' // pwacompat should add 'meta[name="mobile-web-app-capable"][content="yes"]'
     };
-    test('should add `mobile-web-app-capable`', async () => {
-      const r = await testManifest(manifest);
-      assert.isNotNull(r.querySelector('meta[name="mobile-web-app-capable"][content="yes"]'));
-    });
-    test('should not add `mobile-web-app-capable` if it was present beforehand', async () => {
-      const r = await testManifest(manifest, '<meta name="mobile-web-app-capable" content="existing">');
-      assert.isNotNull(r.querySelector('meta[name="mobile-web-app-capable"][content="existing"]'));
-      assert.isNull(r.querySelector('meta[name="mobile-web-app-capable"][content="yes"]'));
-      assert.lengthOf(r.querySelectorAll('meta[name="mobile-web-app-capable"]'), 1, 'found only one node')
-    });
-  })
+    const r = await testManifest(manifest, '<meta name="mobile-web-app-capable" content="existing">');
+    assert.isNotNull(r.querySelector('meta[name="mobile-web-app-capable"][content="existing"]'));
+    assert.isNull(r.querySelector('meta[name="mobile-web-app-capable"][content="yes"]'));
+    assert.lengthOf(r.querySelectorAll('meta[name="mobile-web-app-capable"]'), 1, 'found only one node');
+  });
+
+  test('should not add link icon if it was present beforehand', async () => {
+    const manifest = {
+      'icons': [{
+          'src': 'NEW-192.png',
+          'sizes': '192x192'
+        },
+      ],
+    };
+    const r = await testManifest(manifest, '<link rel="icon" href="EXISTING-192.png" sizes="192x192">');
+    assert.isNotNull(r.querySelector('link[rel="icon"][href="EXISTING-192.png"][sizes="192x192"]'));
+    assert.isNull(r.querySelector('link[rel="icon"][href="NEW-192.png"][sizes="192x192"]'));
+  });
 
   // TODO(samthor): Emulate/force userAgent and other environments to test Edge/iOS.
 });


### PR DESCRIPTION
Resolves #41. It's checking if `<link>`s or `<meta>`s were previously on the `<head>` before `append`ing them. Previously this check was only done for meta `theme-color`.

- Added helper functions
- Added test accordingly

Probably it needs better code formatting, following Google guidelines 😉😬 