### PR TITLE
Fix ReferenceError largestSize on iOS

### DIFF
--- a/src/pwacompat.js
+++ b/src/pwacompat.js
@@ -210,7 +210,7 @@ function unused() {
       if (!isSafariMobile) {
         return;
       }
-      const dim = largestSize(icon);
+      const dim = icon.largestSize;
       if (dim < appleIconSizeMin) {
         return;
       }


### PR DESCRIPTION
Fix a ReferenceError largestSize thrown on iOS since commit: 35fc09d  
Icons and splash screens images was not inserted in the page.

This fix bug #53